### PR TITLE
Compile: Fix compile warnings from InputFormat

### DIFF
--- a/sdk/include/alibabacloud/oss/model/InputFormat.h
+++ b/sdk/include/alibabacloud/oss/model/InputFormat.h
@@ -59,7 +59,7 @@ namespace OSS
 
     protected:
         InputFormat();
-	virtual ~InputFormat() = default;
+        virtual ~InputFormat() = default;
         friend SelectObjectRequest;
         friend CreateSelectObjectMetaRequest;
         virtual int validate() const;

--- a/sdk/include/alibabacloud/oss/model/InputFormat.h
+++ b/sdk/include/alibabacloud/oss/model/InputFormat.h
@@ -59,6 +59,7 @@ namespace OSS
 
     protected:
         InputFormat();
+	virtual ~InputFormat() = default;
         friend SelectObjectRequest;
         friend CreateSelectObjectMetaRequest;
         virtual int validate() const;


### PR DESCRIPTION
The destructor should be virtual if a class is defined as an abstract class.

```
include/alibabacloud/oss/model/InputFormat.h:76:35: warning: base class 'class AlibabaCloud::OSS::InputFormat' has accessible non-virtual destructor [-Wnon-virtual-dtor] 
    class ALIBABACLOUD_OSS_EXPORT CSVInputFormat : public InputFormat
```